### PR TITLE
Update README.md - With Links working for labs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# tecnico-distsys.github.io
+tecnico-distsys web site
+
 # IST - Distributed Systems
 Distributed Systems  - Instituto Superior Tecnico - Practical Assignments
 


### PR DESCRIPTION
It has all the working links to every lab. I was expecting that the lab of Web Service Tests would have its own content. But it doesn't occur
